### PR TITLE
Fix Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - '*'
-      - '!development_old_nwjs'
     tags:
       - 'v*'
 
@@ -52,35 +51,18 @@ jobs:
           key: "${{ matrix.os }}"
           map: |
             {
-              "ubuntu-latest": { "platform": "linux" },
-              "macOS-latest": { "platform": "osx" },
-              "windows-latest": { "platform": "win" }
+              "ubuntu-latest": { "platform": "linux", "dist": "linux32,linux64" },
+              "macOS-latest": { "platform": "osx", "dist": "osx64" },
+              "windows-latest": { "platform": "win", "dist": "win32,win64" }
             }
 
-      - name: Build info macOS
-        if: matrix.os == 'macOS-latest'
-        run: |
-          echo Build ${{ env.platform }}64 on nw-v${{ matrix.nwjs }}
+      - name: Build info
+        run: echo Build ${{ env.dist }} on nw-v${{ matrix.nwjs }}
 
-      - name: Build info Linux & Windows
-        if: matrix.os != 'macOS-latest'
-        run: |
-          echo Build ${{ env.platform }}32 on nw-v${{ matrix.nwjs }}
-          echo Build ${{ env.platform }}64 on nw-v${{ matrix.nwjs }}
-
-      - name: Build macOS
-        if: matrix.os == 'macOS-latest'
+      - name: Build App
         run: |
           yarn
-          yarn gulp dist --platforms=${{ env.platform }}64 --nwVersion=${{ matrix.nwjs }}
-
-      - name: Build Linux & Windows
-        if: matrix.os != 'macOS-latest'
-        run: |
-          yarn
-          yarn gulp dist --platforms=${{ env.platform }}32 --nwVersion=${{ matrix.nwjs }}
-          yarn gulp dist --platforms=${{ env.platform }}64 --nwVersion=${{ matrix.nwjs }}
-
+          yarn gulp dist --platforms=${{ env.platform == 'win' && '"' || '' }}${{ env.dist }}${{ env.platform == 'win' && '"' || '' }} --nwVersion=${{ matrix.nwjs }}
       - name: Upload artifacts
         uses: actions/upload-artifact@master
         with:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -536,7 +536,7 @@ gulp.task('nsis', () => {
 
         // spawn isn't exec
         const makensis =
-          process.platform === 'win32' ? 'makensis.exe' : 'makensis';
+          platform === 'win32' ? 'makensis.exe' : 'makensis';
 
         const child = spawn(makensis, [
           './dist/windows/installer_makensis.nsi',
@@ -631,7 +631,7 @@ gulp.task('prepareUpdater', () => {
 
         // list of commands
         let excludeCmd = '--exclude .git';
-        if (process.platform.indexOf('linux') !== -1) {
+        if (platform.indexOf('linux') !== -1) {
           excludeCmd = '--exclude-vcs';
         }
 


### PR DESCRIPTION
@ivan1986 any ideas? Seems to fail at the nsis function. I thought changing `process.platform` to `platform` would fix it, since at least on Windows it always returns 'win32' while `platform` returns the correct one, but there still seems to be an issue somewhere.