### PR TITLE
Fix fullscreen overlay 3

### DIFF
--- a/src/app/lib/views/player/player.js
+++ b/src/app/lib/views/player/player.js
@@ -9,7 +9,6 @@
         prevSub: null,
         wasFullscreen: false,
         wasMinimized: false,
-        newNW: null,
 
         ui: {
             eyeInfo: '.eye-info-player',
@@ -331,12 +330,6 @@
             // set volume
             this.player.volume(Settings.playerVolume);
 
-            // fixes fullscreen subtitles and fullscreen player UI weirdness with new NW.js
-            // should be removed if a future NW.js or Video.js update resolves it
-            if (this.newNW) {
-                $('#video_player_html5_api').css({'width': '102%', 'left': '-1%'});
-            }
-
             // resume position
             if (Settings.lastWatchedTitle === this.model.get('title') && Settings.lastWatchedTime > 0) {
                 var position = Settings.lastWatchedTime;
@@ -446,7 +439,6 @@
             $('.filter-bar').show();
             $('#player_drag').show();
             var that = this;
-            that.newNW = parseFloat(process.versions['node-webkit'].replace('0.', '')) > 50 ? true : false;
 
             $('.button:not(#download-torrent), .show-details .sdo-watch, .sdow-watchnow, .show-details #download-torrent, .file-item, .file-item a, .result-item, .collection-paste, .collection-import, .seedbox .item-play, #torrent-list .item-row, #torrent-show-list .item-row').addClass('disabled');
             $('#watch-now, #watch-trailer, .playerchoice, .file-item, .file-item a, .result-item, .result-item > *:not(.item-icon), .seedbox .item-play, #torrent-list .item-play, #torrent-show-list .item-play').prop('disabled', true);
@@ -1188,15 +1180,14 @@
             var curVideo = $('#video_player_html5_api');
             if (curVideo[0]) {
                 var multPer = ((curVideo[0].videoWidth / curVideo[0].videoHeight) / (screen.width / screen.height))*100;
-                var fsMult = this.newNW ? 1.02 : 1;
-                if ((curVideo.width() / fsMult) > $('#video_player').width() || curVideo.height() > $('#video_player').height()) {
-                    curVideo.css({'width': fsMult * 100 + '%','height': '100%', 'left': (this.newNW ? -1 : 0) + '%', 'top': '0'});
+                if (curVideo.width() > $('#video_player').width() || curVideo.height() > $('#video_player').height()) {
+                    curVideo.removeAttr('style');
                     this.displayOverlayMsg(i18n.__('Original'));
                 } else if (multPer > 100) {
-                    curVideo.css({'width': multPer + '%', 'left': 50-multPer/2 + '%'});
+                    curVideo.css({'width': multPer + '%', 'left': 50-multPer/2 + '%', 'border': 'none'});
                     this.displayOverlayMsg(i18n.__('Fit screen'));
                 } else if (multPer < 100) {
-                    curVideo.css({'height': 10000/multPer + '%', 'top': 50-5000/multPer + '%'});
+                    curVideo.css({'height': 10000/multPer + '%', 'top': 50-5000/multPer + '%', 'border': 'none'});
                     this.displayOverlayMsg(i18n.__('Fit screen'));
                 } else {
                     this.displayOverlayMsg(i18n.__('Video already fits screen'));

--- a/src/app/styl/views/player.styl
+++ b/src/app/styl/views/player.styl
@@ -8,6 +8,9 @@
   position: fixed
   width: 100%
   height: 100%
+  display: flex
+  align-items: center
+  justify-content: center
 }
 
 .player {

--- a/src/app/styl/views/videojs.styl
+++ b/src/app/styl/views/videojs.styl
@@ -720,10 +720,11 @@
     }
     .vjs-tech {
         position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
+        top: auto;
+        left: auto;
+        width: auto;
+        height: auto;
+        border: 100vw solid #000;
     }
     &.vjs-fullscreen {
         position: fixed;

--- a/src/app/styl/views/videojs.styl
+++ b/src/app/styl/views/videojs.styl
@@ -720,11 +720,11 @@
     }
     .vjs-tech {
         position: absolute;
-        top: auto;
-        left: auto;
-        width: auto;
-        height: auto;
-        border: 100vw solid #000;
+        top: -50vw;
+        left: -50vw;
+        width: calc(100% + 100vw);
+        height: calc(100% + 100vw);
+        border: 50vw solid #000;
     }
     &.vjs-fullscreen {
         position: fixed;


### PR DESCRIPTION
*reverts #2914 ..

Out of the 3 solutions this is the best one, no other layers on top of the video(1st one), no transforming or scaling of the video(2nd), just an (out of viewport) border property for the div using a couple of lines of pure css and everything behaves normally again like the old NW.js build already does.