### PR TITLE
Allow the Seedbox to display above the Torrent Collection

### DIFF
--- a/src/app/lib/views/browser/filter_bar.js
+++ b/src/app/lib/views/browser/filter_bar.js
@@ -357,36 +357,38 @@
     showTorrentCollection: function(e) {
       e.preventDefault();
       if (App.currentview !== 'Torrent-collection') {
-        if (App.currentview === 'Seedbox') {
-          App.currentview = App.previousview;
-          App.vent.trigger('seedbox:close');
+        if (App.currentview !== 'Seedbox') {
+          App.previousview = App.currentview;
         }
-        App.previousview = App.currentview;
         App.currentview = 'Torrent-collection';
         App.vent.trigger('about:close');
+        App.vent.trigger('seedbox:close');
         App.vent.trigger('torrentCollection:show');
         this.setActive('Torrent-collection');
       } else {
-        App.currentview = App.previousview;
-        App.vent.trigger('torrentCollection:close');
+        if (!App.ViewStack.includes('seedbox')) {
+          App.currentview = App.previousview;
+          App.vent.trigger('torrentCollection:close');
+        }
+        App.vent.trigger('seedbox:close');
         this.setActive(App.currentview);
       }
     },
 
     showSeedbox: function(e) {
       e.preventDefault();
-      if (App.currentview !== 'Seedbox') {
-        if (App.currentview === 'Torrent-collection') {
-          App.currentview = App.previousview;
-          App.vent.trigger('torrentCollection:close');
+      if (!App.ViewStack.includes('seedbox')) {
+        if (App.currentview !== 'Torrent-collection') {
+          App.previousview = App.currentview;
+          App.currentview = 'Seedbox';
         }
-        App.previousview = App.currentview;
-        App.currentview = 'Seedbox';
         App.vent.trigger('about:close');
         App.vent.trigger('seedbox:show');
         this.setActive('Seedbox');
       } else {
-        App.currentview = App.previousview;
+        if (App.currentview !== 'Torrent-collection') {
+          App.currentview = App.previousview;
+        }
         App.vent.trigger('seedbox:close');
         this.setActive(App.currentview);
       }

--- a/src/app/lib/views/file_selector.js
+++ b/src/app/lib/views/file_selector.js
@@ -78,8 +78,10 @@
             App.vent.trigger('system:closeFileSelector');
             if ($(e.currentTarget).hasClass('item-download')) {
                 if (Settings.showSeedboxOnDlInit) {
-                    App.vent.trigger('torrentCollection:close');
-                    App.currentview = 'Seedbox';
+                    if (App.currentview !== 'Torrent-collection') {
+                        App.previousview = App.currentview;
+                        App.currentview = 'Seedbox';
+                    }
                     App.vent.trigger('seedbox:show');
                     $('.filter-bar').find('.active').removeClass('active');
                     $('#filterbar-seedbox').addClass('active');


### PR DESCRIPTION
This already was the case for every other content tab/view/detail view, but not for the Torrent Collection which was closed when you opened the Seedbox (either by the filterbar or by downloading something). This PR fixes this.