### PR TITLE
fix: rust lint

### DIFF
--- a/.github/workflows/lint-rust.yaml
+++ b/.github/workflows/lint-rust.yaml
@@ -7,6 +7,7 @@ on:
       - main
   pull_request:
     paths:
+      - Cargo.lock
       - ".github/workflows/lint-rust.yml"
       - "crates/**"
 


### PR DESCRIPTION
## 🧢 Changes
Add `Cargo.lock` to `workflows/lint-rust.yaml`

## ☕️ Reasoning
Make sure cargo works as expected after a `cargo update -p` that doesnt bump the `Cargo.toml`
<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
