### PR TITLE
fix: splash

### DIFF
--- a/apps/desktop/src/routes/splash.test.tsx
+++ b/apps/desktop/src/routes/splash.test.tsx
@@ -69,6 +69,7 @@ describe("SplashRoute", () => {
 	it("redirects to login when onboarded but session is not active", async () => {
 		useGlobalStore.setState(s => {
 			s.app.boot = "booted";
+			s.session.status = "ready";
 			s.settings.onboardingComplete = true;
 		});
 

--- a/apps/desktop/src/routes/splash.tsx
+++ b/apps/desktop/src/routes/splash.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
+import { useShallow } from "zustand/shallow";
 import { SplashScreen } from "@/components/splash-screen";
 import { useGlobalStore } from "@/stores/global";
-import { useShallow } from "zustand/shallow";
 
 export function SplashRoute() {
 	const appBoot = useGlobalStore(s => s.app.boot);

--- a/apps/desktop/src/routes/splash.tsx
+++ b/apps/desktop/src/routes/splash.tsx
@@ -2,11 +2,12 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router";
 import { SplashScreen } from "@/components/splash-screen";
 import { useGlobalStore } from "@/stores/global";
+import { useShallow } from "zustand/shallow";
 
 export function SplashRoute() {
 	const appBoot = useGlobalStore(s => s.app.boot);
 	const onboarded = useGlobalStore(s => s.settings.onboardingComplete);
-	const isActive = useGlobalStore(s => s.session.isActive);
+	const { isActive, status: sessionStatus } = useGlobalStore(useShallow(s => s.session));
 	const preferredCountry = useGlobalStore(s => s.preferences.country);
 	const initialRedirectAttempted = useRef(false);
 	const navigate = useNavigate();
@@ -29,12 +30,13 @@ export function SplashRoute() {
 				}
 			}
 		} else {
-			if (!initialRedirectAttempted.current) {
+			// make sure session is fully loaded
+			if (!initialRedirectAttempted.current && sessionStatus === "ready") {
 				initialRedirectAttempted.current = true;
 				navigate("/login", { flushSync: true });
 			}
 		}
-	}, [appBoot, onboarded, isActive, navigate, preferredCountry]);
+	}, [appBoot, onboarded, isActive, navigate, preferredCountry, sessionStatus]);
 
 	return <SplashScreen />;
 }


### PR DESCRIPTION
## 🧢 Changes
- make sure session is fully loaded before redirecting to login

## ☕️ Reasoning
we need to make sure our session is ready before hitting the login page
this keep the splash then browe when logged instead of hopping on login

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->
